### PR TITLE
Update Prometheus systemd service instructions

### DIFF
--- a/class-material/u1/3-Iot_Stack/readme.md
+++ b/class-material/u1/3-Iot_Stack/readme.md
@@ -108,7 +108,9 @@ scrape_configs:
       - targets: ['localhost:9100']
 ```
 
-Genera un servicio systemd para Prometheus. Después de crear o modificar archivos de unidad, es necesario recargar la configuración de systemd mediante `systemctl daemon‑reload`:
+Genera un servicio systemd para Prometheus. Después de crear o modificar archivos de unidad, es necesario recargar la configuración de systemd mediante `sudo systemctl daemon‑reload`:
+
+(Super importante escribir `sudo` antes de, por que te pedirá una contraseña y te dará error)
 
 ```bash
 sudo tee /etc/systemd/system/prometheus.service <<'EOF'


### PR DESCRIPTION
Added 'sudo' to the systemd service reload command for Prometheus and clarified the importance of using it.